### PR TITLE
Make JSON number parser locale-independent

### DIFF
--- a/src/XParsec.Json/JsonParser.fs
+++ b/src/XParsec.Json/JsonParser.fs
@@ -2,6 +2,7 @@ namespace XParsec.Json
 
 open System
 open System.Collections.Immutable
+open System.Globalization
 open System.Text
 
 open XParsec
@@ -84,7 +85,7 @@ type JsonParsers<'Input, 'InputSlice
 
                 let number = sb.ToString()
 
-                match Double.TryParse(number) with
+                match Double.TryParse(number, CultureInfo.InvariantCulture) with
                 | true, result -> preturn result
                 | _ -> failwithf "Failed to parse number: %s" number
 


### PR DESCRIPTION
When run on a system with a locale that uses `.` as thousands-separator, the parser will interpret `1.234` as `1234`. The tests do catch this when run on such a system.

This commit fixes this by adding `CultureInfo.InvariantCulture` to the call to `Double.TryParse`.

Fixes #8.