### PR TITLE
Make `sepEndBy` allow main parser to succeed without consuming input

### DIFF
--- a/src/XParsec/Combinators.fs
+++ b/src/XParsec/Combinators.fs
@@ -918,7 +918,7 @@ module Combinators =
                 match pSep reader with
                 | Ok sep ->
                     seps.Add(sep.Parsed)
-                    let pos = reader.Position
+                    let posSep = reader.Position
 
                     match p reader with
                     | Ok s ->
@@ -927,7 +927,7 @@ module Combinators =
 
                         xs.Add(s.Parsed)
                     | Error _ ->
-                        reader.Position <- pos
+                        reader.Position <- posSep
                         ok <- false
                 | Error e ->
                     reader.Position <- pos

--- a/test/XParsec.Tests/CombinatorTests.fs
+++ b/test/XParsec.Tests/CombinatorTests.fs
@@ -1240,13 +1240,32 @@ let tests =
 
                     "" |> Expect.equal reader.Index 18L
                 | Error e -> failwithf "%A" e
+                
+                let input = "input,,input,X"
+
+                let p1 = pstring "input" |> opt
+                let p2 = pchar ','
+                let p = sepEndBy p1 p2
+                let reader = Reader.ofString input ()
+                let result = p reader
+
+                match result with
+                | Ok result ->
+                    ""
+                    |> Expect.equal
+                        result.Parsed
+                        ([| ValueSome "input"; ValueNone; ValueSome "input"; ValueNone |].ToImmutableArray(),
+                         ImmutableArray.CreateRange([| ','; ','; ',' |]))
+
+                    "" |> Expect.equal reader.Index 13L
+                | Error e -> failwithf "%A" e
 
                 let reader = Reader.ofString "X" ()
                 let result = p reader
 
                 match result with
                 | Ok result ->
-                    "" |> Expect.equal result.Parsed (ImmutableArray.Empty, ImmutableArray.Empty)
+                    "" |> Expect.equal result.Parsed ([| ValueNone |].ToImmutableArray(), ImmutableArray.Empty)
                     "" |> Expect.equal reader.Index 0L
                 | Error e -> failwithf "%A" e
 


### PR DESCRIPTION
It looks like the other repetetional combinators (at least `sepBy` and `sepEndBy1`) require parsing to progress after both `p` and `sep` have run, throwing `InfiniteLoopException` otherwise. For `sepEndBy` however, the exception is thrown even if just `p` doesn't consume.

This commit copies the behavior from `sepBy1` by checking against `pos` from before `p reader` was run.

Resolves #10.